### PR TITLE
Fix help text and adapt to new rules format

### DIFF
--- a/lib/card/catalogue_adapters/json_catalogue_adapter.rb
+++ b/lib/card/catalogue_adapters/json_catalogue_adapter.rb
@@ -124,7 +124,7 @@ module Card
       end
 
       def extract_simple_rule(rules)
-        return Card::Models::SimpleRules.new(rules) if rules.is_a?(String)
+        return Card::Models::SimpleRules.new(rules["active"]) if rules["passive"].nil?
       end
 
       def extract_active_passive_rule(rules)

--- a/lib/cardmaster/commands/query.rb
+++ b/lib/cardmaster/commands/query.rb
@@ -5,10 +5,10 @@ module Cardmaster
     class Query < Cardmaster::Command
       include Arguments
 
-      SUPPORTED_PARAMETERS = ["name"].freeze
+      SUPPORTED_PARAMETERS = ["title"].freeze
 
       def call(args, _name)
-        query_parameters = validate_parameters(named_arguments(args)) 
+        query_parameters = validate_parameters(named_arguments(args))
 
         if query_parameters.nil?
           puts Query.help
@@ -42,7 +42,7 @@ module Cardmaster
       def validate_parameters(query_parameters)
         if (invalid_parameters = query_parameters.keys.select { |key| !SUPPORTED_PARAMETERS.include?(key) }).size > 0
           puts "Invalid query parameters: #{invalid_parameters}"
-          return 
+          return
         end
 
         query_parameters
@@ -60,12 +60,12 @@ module Cardmaster
         CLI::UI::Frame.open(card_spec.title, color: box_color(card_spec.tier)) {
           case card_spec.rules
           when Card::Models::SimpleRules
-            puts "Rules: #{card_spec.rules.text}" 
+            puts "Rules: #{card_spec.rules.text}"
           when Card::Models::PassiveActiveRules
             puts "Passive: #{card_spec.rules.passive}"
             puts "Active: #{card_spec.rules.active}"
           else
-            raise "Invalid Rule type #{card_spec.rules.class}" 
+            raise "Invalid Rule type #{card_spec.rules.class}"
           end
           puts "Flavour: #{card_spec.flavour}"
           puts "Art: #{card_spec.art_path}"


### PR DESCRIPTION
The help text was wrong, I've updated the command to match it.

The rules format in the json files changed recently, I've updated the catalogue adapter to deal with the change.

Rules used to be in one of two formats:
```
"rules": "The active ability"
```
and
```
"rules": { "passive": "The passive ability", "active": "The active ability" }
```

Now there's only one format with a nullable field:
```
"rules": { "passive": null, "active": "The active ability" }
```
  