### PR TITLE
Add generate command to new CLI

### DIFF
--- a/lib/card/generators.rb
+++ b/lib/card/generators.rb
@@ -1,2 +1,1 @@
-require_relative "./generators/vips_basic.rb"
 require_relative "./generators/imgkit_basic.rb"

--- a/lib/card/storage_adapters/git_storage_adapter.rb
+++ b/lib/card/storage_adapters/git_storage_adapter.rb
@@ -9,19 +9,19 @@ module Card
       ASSET_BASE = "assets/core/card"
       FRONT_PATH = File.join(ASSET_BASE, "printed")
       BACK_PATH = File.join(ASSET_BASE, "back")
-      PRINT_MANIFEST_PATH = "assets/core/card/printed/print_manifest.json"
       GH_URL = "https://raw.githubusercontent.com/elliottomlinson/rpcg"
-      HELP_SUGGESTION = "try printing again or reverting changes to #{PRINT_MANIFEST_PATH}"
+      HELP_SUGGESTION = "try printing again or reverting changes to #{@print_manifest_path}"
 
-      def initialize
-        if File.exists?(PRINT_MANIFEST_PATH)
-          @stored_cards = Marshal.load(File.read(PRINT_MANIFEST_PATH))
+      def initialize(print_manifest_path)
+        @print_manifest_path = print_manifest_path
+        if File.exists?(@print_manifest_path)
+          @stored_cards = Marshal.load(File.read(@print_manifest_path))
           raise "Print Manifest Invalid, #{HELP_SUGGESTION}" unless @stored_cards.is_a?(Hash) && @stored_cards.all? do |title, stored_card|
             stored_card.is_a?(Card::Models::StoredCard)
             title.is_a?(String)
           end
         else
-          puts "Warning: No Print Manifest found at #{PRINT_MANIFEST_PATH}"
+          puts "Warning: No Print Manifest found at #{@print_manifest_path}"
           @stored_cards = {}
         end
       end
@@ -70,7 +70,7 @@ module Card
       end
 
       def update_manifest
-        File.write(PRINT_MANIFEST_PATH, Marshal.dump(@stored_cards))
+        File.write(@print_manifest_path, Marshal.dump(@stored_cards))
       end
 
       def front_path(card_spec)

--- a/lib/cardmaster.rb
+++ b/lib/cardmaster.rb
@@ -1,8 +1,11 @@
 require 'cli/ui'
 require 'cli/kit'
+require "tmpdir"
 require_relative 'cardmaster/arguments'
 require_relative "./card/catalogue_adapters.rb"
+require_relative "./card/storage_adapters.rb"
 require_relative "./card/models.rb"
+require_relative "./card/generators.rb"
 
 CLI::UI::StdoutRouter.enable
 

--- a/lib/cardmaster/arguments.rb
+++ b/lib/cardmaster/arguments.rb
@@ -1,5 +1,7 @@
 module Arguments
 	NAMED_ARGUMENT_REGEX = /--(.*)=(.*)/
+  FLAG_REGEX = /--([^=]*)/
+
 	def named_arguments(args)
 		args.each_with_object({}) do |arg, dict|
 			match = NAMED_ARGUMENT_REGEX.match(arg)
@@ -8,4 +10,19 @@ module Arguments
 			dict[match[1]] = match[2]
 		end
 	end
+
+	def flag_arguments(args)
+    args.map do |arg|
+      next unless NAMED_ARGUMENT_REGEX.match(arg).nil?
+      next if (match = FLAG_REGEX.match(arg)).nil?
+
+      match[1]
+    end.compact
+	end
+
+  def positional_arguments(args)
+    args.select do |arg|
+      NAMED_ARGUMENT_REGEX.match(arg).nil? && FLAG_REGEX.match(arg).nil?
+    end
+  end
 end

--- a/lib/cardmaster/commands.rb
+++ b/lib/cardmaster/commands.rb
@@ -13,6 +13,7 @@ module Cardmaster
     end
 
     register :Query, 'query', 'cardmaster/commands/query'
+    register :Generate, 'generate', 'cardmaster/commands/generate'
     register :Help,    'help',    'cardmaster/commands/help'
   end
 end

--- a/lib/cardmaster/commands/generate.rb
+++ b/lib/cardmaster/commands/generate.rb
@@ -1,0 +1,113 @@
+require 'cardmaster'
+
+module Cardmaster
+  module Commands
+    class Generate < Cardmaster::Command
+      include Arguments
+
+      SUPPORTED_FLAGS = ["all"].freeze
+
+      MANIFEST_PATH = "data/print_manifest.json"
+
+      def call(args, _name)
+        flags = flag_arguments(args)
+
+        flags.each do |flag|
+          unless SUPPORTED_FLAGS.include?(flag)
+            puts "Unrecognized flag #{flag}"
+            puts Generate.help
+
+            return
+          end
+        end
+
+        specified_cards = positional_arguments(args)
+
+        print_count = 0
+        Dir.mktmpdir do |tmp_dir|
+          printed_cards = spec_diffs.map.with_index do |spec_diff, index|
+            next if spec_diff[:old] == spec_diff[:new] && !flags.include?("all")
+            next if specified_cards && !specified_cards.include?(spec_diff[:new].title)
+
+            print_count += 1
+
+            card_spec = spec_diff[:new]
+            puts "Printing #{card_spec.title}..."
+
+            image_path = File.join(tmp_dir, "#{index}.png")
+
+            generator.generate(card_spec, image_path)
+
+            Card::Models::PrintedCard.new(
+              image_path,
+              card_spec,
+              card_backs[card_spec.tier]
+            )
+          end.compact
+
+          if print_count == 0
+            puts "Stored cards are up to date."
+          else
+            puts "Printed #{print_count} cards. Storing..."
+            storage_adapter.save(printed_cards)
+          end
+          puts "All Finished."
+        end
+      end
+
+      def self.help
+        "A dummy command.\nUsage: {{command:#{Cardmaster::TOOL_NAME} query --title=[card title]}}"
+      end
+
+      private
+
+      def spec_diffs
+        return @spec_diffs if @spec_diffs
+
+        stored_card_specs = storage_adapter.stored_cards.map(&:spec)
+        card_specs = catalogue_adapter.printable_cards
+
+        puts "Found #{stored_card_specs.length} stored cards..."
+        puts "Found #{card_specs.length} cards specified in catalogue..."
+
+        printed_by_title = stored_card_specs.each_with_object({}) do |card_spec, title_hash|
+          title_hash[card_spec.title] = card_spec
+        end
+
+        specified_by_title = card_specs.each_with_object({}) do |card_spec, title_hash|
+          title_hash[card_spec.title] = card_spec
+        end
+
+        stored_card_specs.map do |card_spec|
+          if specified_by_title[card_spec.title].nil?
+            puts "Deleting printed card missing from spec #{card_spec.title}..."
+            storage_adapter.delete(card_spec.title)
+          end
+        end
+
+        @spec_diffs = card_specs.map do |card_spec|
+          {
+            old: printed_by_title[card_spec.title],
+            new: card_spec
+          }
+        end
+
+      end
+
+      def generator
+        card_templates = ->(card_spec) do
+          "assets/core/card/template/default.html"
+        end
+        @generator ||= Card::Generators::IMGKitBasic.new(card_templates, [])
+      end
+
+      def catalogue_adapter
+        @catalogue_adapter ||= Card::CatalogueAdapters::JsonCatalogueAdapter.new("data/card_catalogue")
+      end
+
+      def storage_adapter
+        @storage_adapter ||= Card::StorageAdapters::GitStorageAdapter.new(MANIFEST_PATH)
+      end
+    end
+  end
+end

--- a/lib/cardmaster/commands/query.rb
+++ b/lib/cardmaster/commands/query.rb
@@ -19,8 +19,6 @@ module Cardmaster
           .printable_cards
           .select { |card_spec| matches_query(card_spec, query_parameters) }
 
-
-
         CLI::UI::Frame.open('Search Results') do
           if results.empty?
             puts CLI::UI.fmt "{{x}} No results found."


### PR DESCRIPTION
Generate command:
```
cardmaster generate [--all]
```
Generates all cards which have changed since the last printing (according to the print manifest) or prints all cards with the `--all` flag.

There's an issue with the print manifest system which will need to be resolved so the command is broken, but wanted to touch back into master asap