### PR TITLE
Readme: Add Links and Hover Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,64 +6,108 @@ A simplified tabletop role-playing game with an emphasis on casual play.
 
 As a *Cardmaster*, the player has a hand of single-use cards which allow them to use magical abilities instantly *at any time* during play.
 <p align="center">
-  <img src="https://git.io/JEQYa" width="30%" title="Boost">
+  <img src="https://git.io/JEQYa" width="30%" title="⚡ Move a metre">
 </p>
 
 Since the **⚡ Cast Effect** applies instantly, the seemingly lackluster _Shift_ could be used to dodge a bullet, if played on an opponent's turn. 
 
-In the same situation, cards such as *Fluster*, *Gust of Wind*, and *Anvil Drop* could be used to interfere.
+In the same situation, cards such as 
+  <i><a href="#Fluster" title="⚡ Decrease the result of a roll by 1">Fluster</a></i>, 
+  <i><a href="#Gust of Wind" title="⚡ Throw a visible character up into the air">Gust of Wind</a></i>, and 
+  <i><a href="#Anvil Drop" title="⚡ Summon a cast-steel anvil into existence above target character's head">Anvil Drop</a></i> 
+could be used to interfere.
 
 <br>
 <p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Fluster.png" width="25%" title="Fluster">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Gust%20of%20Wind.png" width="25%" title="Gust of Wind">
-    <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Anvil%20Drop.png" width="25%" title="Anvil Drop">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Fluster.png" width="25%"
+       id="Fluster" title="⚡ Decrease the result of a roll by 1">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Gust%20of%20Wind.png" width="25%"
+       id="Gust of Wind" title="⚡ Throw a visible character up into the air">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Anvil%20Drop.png" width="25%"
+       id="Anvil Drop" title="⚡ Summon a cast-steel anvil into existence above target character's head">
 </p>
 
-During an ally's turn, *Field Medicine* and *Pigeon Partner* could be cast to help them. Cards like *Lie* and *Seance* can affect social interactions and may be most useful outside of combat.
+During an ally's turn,
+  <i><a href="#Field Medicine" title="⚡ Heal a visible character 15. They can move twice as fast for the remainder of the session &#013;✋ Run twice as fast while carrying friendly characters">Field Medicine</a></i> or
+  <i><a href="#Pigeon Partner" title="⚡ Summon a pigeon to perform a simple task">Pigeon Partner</a></i>
+could be cast to help them. Cards like 
+  <i><a href="#Lie" title="⚡ Target NPC will believe your next statement">Lie</a></i> and
+  <i><a href="#Seance" title="⚡ Speak with any dead NPC. Their voice can be heard by all nearby NPCs.">Seance</a></i>
+can affect social interactions and may be most useful outside of combat.
 
 <br>
 <p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Field%20Medicine.png" width="20%" title="Field Medicine">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Pigeon%20Partner.png" width="20%" title="Pigeon Partner">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lie.png" width="20%" title="Lie">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Seance.png" width="20%" title="Seance">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Field%20Medicine.png" width="20%"
+       id="Field Medicine" title="⚡ Heal a visible character 15. They can move twice as fast for the remainder of the session &#013;✋ Run twice as fast while carrying friendly characters">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Pigeon%20Partner.png" width="20%" 
+       id="Pigeon Partner" title="⚡ Summon a pigeon to perform a simple task">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lie.png" width="20%" 
+       id="Lie" title="⚡ Target NPC will believe your next statement">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Seance.png" width="20%" 
+       id="Seance" title="⚡ Speak with any dead NPC. Their voice can be heard by all nearby NPCs.">
 </p>
 
-Players have the freedom to manipulate the environment to varying degrees with cards like *Eidolimb*, *Soak*, and *Poltergeist*.
+Players have the freedom to manipulate the environment to varying degrees with cards like 
+  <i><a href="#Barrier" title="⚡ Summon an impenetrable column of light in adjacent square metre for 5 minutes">Barrier</a></i>,
+  <i><a href="#Soak" title="⚡ Cause everything within 2 metres of a visible object to become saturated with water">Soak</a></i>, and
+  <i><a href="#Poltergeist" title="⚡ Possess a non-magic object within 5 tiles of your body until you lose concentration.">Poltergeist</a></i>.
 
 <br>
 <p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Barrier.png" width="25%" title="Barrier">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Soak.png" width="25%" title="Soak">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Poltergeist.png" width="25%" title="Poltergeist">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Barrier.png" width="25%" 
+       id="Barrier" title="⚡ Summon an impenetrable column of light in adjacent square metre for 5 minutes">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Soak.png" width="25%" 
+       id="Soak" title="⚡ Cause everything within 2 metres of a visible object to become saturated with water">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Poltergeist.png" width="25%" 
+       id="Poltergeist" title="⚡ Possess a non-magic object within 5 tiles of your body until you lose concentration.">
 </p>
 
-Cards can also have an effect while in a player's hand, as denoted by the **✋ Hand Effect** symbol. Cards with these effects, such as *Rodent Whisperer*, *Slingshot*, and *Lover Fatale*, can help define a character's identity.
+Cards can also have an effect while in a player's hand, as denoted by the **✋ Hand Effect** symbol. Cards with these effects, such as 
+  <i><a href="#Rodent Whisperer" title="⚡ Turn into a rodent for as long as you want &#013;✋ You hold influence over members of Order Rodentia">Rodent Whisperer</a></i>,
+  <i><a href="#Slingshot" title="⚡ Launch a baseball sized rock at a visible target &#013;✋ Gain advantage when throwing objects">Slingshot</a></i>, and
+  <i><a href="#Lover Fatale" title="⚡ A visible NPC develops feelings for you &#013;✋ Attacks against characters who love you deal 25 bonus damage">Lover Fatale</a></i>
+can help define a character's identity.
 
 <br>
 <p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Rodent%20Whisperer.png" width="20%" title="Rodent Whisperer">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Slingshot.png" width="20%" title="Slingshot">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lover%20Fatale.png" width="20%" title="Lover Fatale">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Rodent%20Whisperer.png" width="20%" 
+       id="Rodent Whisperer" title="⚡ Turn into a rodent for as long as you want &#013;✋ You hold influence over members of Order Rodentia">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Slingshot.png" width="20%" 
+       id="Slingshot" title="⚡ Launch a baseball sized rock at a visible target &#013;✋ Gain advantage when throwing objects">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lover%20Fatale.png" width="20%" 
+       id="Lover Fatale" title="⚡ A visible NPC develops feelings for you &#013;✋ Attacks against characters who love you deal 25 bonus damage">
 </p>
 
-Cardmaster's tier/rarity order is: ⚫ Grey, 🔵 Blue, 🟢 Green, 🔴 Red, 🟡 Gold. The player can upgrade a card of a certain tier in exchange for three cards of the same tier. Some cards belong to a series - guaranteeing a particular result when upgrading them, as shown below with *Spark*, *Lightning Bolt*, *Fork Lightning*, and finally *Elektra's Siphon*.
+Cardmaster's tier/rarity order is: ⚫ Grey, 🔵 Blue, 🟢 Green, 🔴 Red, 🟡 Gold. The player can upgrade a card of a certain tier in exchange for three cards of the same tier. Some cards belong to a series - guaranteeing a particular result when upgrading them, as shown below with 
+
+  <i><a href="#Spark" title="⚡ Deal 3 damage to a visible character with a painful bolt of electricity">Spark</a></i>,
+  <i><a href="#Lightning Bolt" title="⚡ Deal 4 damage and stun up to 2 visible characters.">Lightning Bolt</a></i>, and
+  <i><a href="#Fork Lightning" title="⚡ Deal 6 damage and stun to up to 6 visible characters.">Fork Lightning</a></i>.
+   <i><a href="#Elektra's Siphon" title="⚡Cause a complete blackout in a 100 kilometre radius. Draw 3 copies of Fork Lightning.">Elektra's Siphon</a></i>.
 
 <br>
 <p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Spark.png" width="20%" title="Spark">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lightning%20Bolt.png" width="20%" title="Lightning Bolt">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Fork%20Lightning.png" width="20%" title="Fork Lightning">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Elektra's%20Siphon.png" width="20%" title="Elektra's Siphon">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Spark.png" width="20%" 
+       id="Spark" title="⚡ Deal 3 damage to a visible character with a painful bolt of electricity">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lightning%20Bolt.png" width="20%" 
+       id="Lightning Bolt" title="⚡ Deal 4 damage and stun up to 2 visible characters.">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Fork%20Lightning.png" width="20%" 
+       id="Fork Lightning" title="⚡ Deal 6 damage and stun to up to 6 visible characters.">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Elektra's%20Siphon.png" width="20%" 
+       id="Elektra's Siphon" title="⚡Cause a complete blackout in a 100 kilometre radius. Draw 3 copies of Fork Lightning.">
 </p>
 
-Certain cards like *Untimely Death* and *Heroic Inspiration* can even be used to influence the campaign/story itself.
+Certain cards like 
+ <i><a href="#Untimely Death" title="⚡ Name an NPC. They will be suddenly inspired to seek greatness. By next session they will be incredibly powerful.">Untimely Death</a></i>, and 
+ <i><a href="#Heroic Inspiration" title="⚡ Name a character not on the current map. They die.">Heroic Inspiration</a></i>
+can even be used to influence the campaign at-large.
 
 <br>
 <p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Untimely%20Death.png" width="30%" title="Untimely Death">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Heroic%20Inspiration.png" width="30%" title="Heroic Inspiration">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Untimely%20Death.png" width="30%" 
+       id="Untimely Death" title="⚡ Name a character not on the current map. They die.">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Heroic%20Inspiration.png" width="30%" 
+       id="Heroic Inspiration" title="⚡ Name an NPC. They will be suddenly inspired to seek greatness. By next session they will be incredibly powerful.">
 </p>
 
 ## In This Repository

--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ A simplified tabletop role-playing game with an emphasis on casual play.
 ## The Card System
 
 As a *Cardmaster*, the player has a hand of single-use cards which allow them to use magical abilities instantly *at any time* during play.
-<p align="center">
-  <img src="https://git.io/JEQYa" width="30%" title="⚡ Move a metre">
-</p>
 
-Since the **⚡ Cast Effect** applies instantly, the seemingly lackluster _Shift_ could be used to dodge a bullet, if played on an opponent's turn. 
+The **⚡ Cast Effect** applies instantly, so the seemingly lackluster
+<i><a href="#Shift" title="⚡ Move a metre">Shift</a></i>
+could be used to dodge a bullet, if played on an opponent's turn.
+
+<p align="center">
+  <img src="https://git.io/JEQYa" width="30%" id="Shift" title="⚡ Move a metre">
+</p>
 
 In the same situation, cards such as 
   <i><a href="#Fluster" title="⚡ Decrease the result of a roll by 1">Fluster</a></i>, 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ can even be used to influence the campaign at-large.
 - A CLI tool to assist in importing these cards into *[Tabletop Simulator](https://tabletopsimulator.com/)*
 - *Cardmaster*'s website, located at https://cardmaster.io/
 
----
 
-Created by [Duncan Uszkay](https://github.com/DuncanUszkay1) and [Elliot Tomlinson](https://github.com/elliottomlinson)
+## Authors
+
+[Duncan Uszkay](https://github.com/DuncanUszkay1) and [Elliot Tomlinson](https://github.com/elliottomlinson)
 
 © 2021 Cardmaster

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # Cardmaster
 
-A simplified tabletop role-playing game with an emphasis on casual play.
+*Cardmaster* is a simplified tabletop role-playing game emphasizing casual play.
 
-## The Card System
+## Introduction
 
-As a *Cardmaster*, the player has a hand of single-use cards which allow them to use magical abilities instantly *at any time* during play.
-
-The **⚡ Cast Effect** applies instantly, so the seemingly lackluster
-<i><a href="#Shift" title="⚡ Move a metre">Shift</a></i>
-could be used to dodge a bullet, if played on an opponent's turn.
+The player can cast a card from their hand at any time. Each card has an instant single-use **⚡ Cast Effect**. 
 
 <p align="center">
-  <img src="https://git.io/JEQYa" width="30%" id="Shift" title="⚡ Move a metre">
+  <img src="https://git.io/JEQYa" width="50%" id="#Shift" title="⚡ Move a metre">
 </p>
 
-In the same situation, cards such as 
-  <i><a href="#Fluster" title="⚡ Decrease the result of a roll by 1">Fluster</a></i>, 
-  <i><a href="#Gust of Wind" title="⚡ Throw a visible character up into the air">Gust of Wind</a></i>, and 
-  <i><a href="#Anvil Drop" title="⚡ Summon a cast-steel anvil into existence above target character's head">Anvil Drop</a></i> 
-could be used to interfere.
+On an opponent's turn, the player could
+<i><a href="Shift" title="⚡ Move a metre">Shift</a></i> to dodge,
+  <i><a href="#Fluster" title="⚡ Decrease the result of a roll by 1">Fluster</a></i> them, use a
+  <i><a href="#Gust of Wind" title="⚡ Throw a visible character up into the air">Gust of Wind</a></i>, do an
+  <i><a href="#Anvil Drop" title="⚡ Summon a cast-steel anvil into existence above target character's head">Anvil Drop</a></i> - or all of the above.
 
 <br>
 <p align="center">
@@ -33,84 +29,74 @@ could be used to interfere.
 During an ally's turn,
   <i><a href="#Field Medicine" title="⚡ Heal a visible character 15. They can move twice as fast for the remainder of the session &#013;✋ Run twice as fast while carrying friendly characters">Field Medicine</a></i> or
   <i><a href="#Pigeon Partner" title="⚡ Summon a pigeon to perform a simple task">Pigeon Partner</a></i>
-could be cast to help them. Cards like 
+could help, while
   <i><a href="#Lie" title="⚡ Target NPC will believe your next statement">Lie</a></i> and
   <i><a href="#Seance" title="⚡ Speak with any dead NPC. Their voice can be heard by all nearby NPCs.">Seance</a></i>
-can affect social interactions and may be most useful outside of combat.
+may be best outside of combat.
 
 <br>
 <p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Field%20Medicine.png" width="20%"
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Field%20Medicine.png" width="24%"
        id="Field Medicine" title="⚡ Heal a visible character 15. They can move twice as fast for the remainder of the session &#013;✋ Run twice as fast while carrying friendly characters">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Pigeon%20Partner.png" width="20%" 
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Pigeon%20Partner.png" width="24%" 
        id="Pigeon Partner" title="⚡ Summon a pigeon to perform a simple task">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lie.png" width="20%" 
+    <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lie.png" width="24%" 
        id="Lie" title="⚡ Target NPC will believe your next statement">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Seance.png" width="20%" 
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Seance.png" width="24%" 
        id="Seance" title="⚡ Speak with any dead NPC. Their voice can be heard by all nearby NPCs.">
+
 </p>
 
-Players have the freedom to manipulate the environment to varying degrees with cards like 
+  
+Like
   <i><a href="#Barrier" title="⚡ Summon an impenetrable column of light in adjacent square metre for 5 minutes">Barrier</a></i>,
   <i><a href="#Soak" title="⚡ Cause everything within 2 metres of a visible object to become saturated with water">Soak</a></i>, and
-  <i><a href="#Poltergeist" title="⚡ Possess a non-magic object within 5 tiles of your body until you lose concentration.">Poltergeist</a></i>.
-
-<br>
-<p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Barrier.png" width="25%" 
-       id="Barrier" title="⚡ Summon an impenetrable column of light in adjacent square metre for 5 minutes">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Soak.png" width="25%" 
-       id="Soak" title="⚡ Cause everything within 2 metres of a visible object to become saturated with water">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Poltergeist.png" width="25%" 
-       id="Poltergeist" title="⚡ Possess a non-magic object within 5 tiles of your body until you lose concentration.">
-</p>
-
-Cards can also have an effect while in a player's hand, as denoted by the **✋ Hand Effect** symbol. Cards with these effects, such as 
-  <i><a href="#Rodent Whisperer" title="⚡ Turn into a rodent for as long as you want &#013;✋ You hold influence over members of Order Rodentia">Rodent Whisperer</a></i>,
-  <i><a href="#Slingshot" title="⚡ Launch a baseball sized rock at a visible target &#013;✋ Gain advantage when throwing objects">Slingshot</a></i>, and
-  <i><a href="#Lover Fatale" title="⚡ A visible NPC develops feelings for you &#013;✋ Attacks against characters who love you deal 25 bonus damage">Lover Fatale</a></i>
-can help define a character's identity.
-
-<br>
-<p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Rodent%20Whisperer.png" width="20%" 
-       id="Rodent Whisperer" title="⚡ Turn into a rodent for as long as you want &#013;✋ You hold influence over members of Order Rodentia">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Slingshot.png" width="20%" 
-       id="Slingshot" title="⚡ Launch a baseball sized rock at a visible target &#013;✋ Gain advantage when throwing objects">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lover%20Fatale.png" width="20%" 
-       id="Lover Fatale" title="⚡ A visible NPC develops feelings for you &#013;✋ Attacks against characters who love you deal 25 bonus damage">
-</p>
-
-Cardmaster's tier/rarity order is: ⚫ Grey, 🔵 Blue, 🟢 Green, 🔴 Red, 🟡 Gold. The player can upgrade a card of a certain tier in exchange for three cards of the same tier. Some cards belong to a series - guaranteeing a particular result when upgrading them, as shown below with 
-
-  <i><a href="#Spark" title="⚡ Deal 3 damage to a visible character with a painful bolt of electricity">Spark</a></i>,
-  <i><a href="#Lightning Bolt" title="⚡ Deal 4 damage and stun up to 2 visible characters.">Lightning Bolt</a></i>, and
-  <i><a href="#Fork Lightning" title="⚡ Deal 6 damage and stun to up to 6 visible characters.">Fork Lightning</a></i>.
-   <i><a href="#Elektra's Siphon" title="⚡Cause a complete blackout in a 100 kilometre radius. Draw 3 copies of Fork Lightning.">Elektra's Siphon</a></i>.
-
-<br>
-<p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Spark.png" width="20%" 
-       id="Spark" title="⚡ Deal 3 damage to a visible character with a painful bolt of electricity">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lightning%20Bolt.png" width="20%" 
-       id="Lightning Bolt" title="⚡ Deal 4 damage and stun up to 2 visible characters.">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Fork%20Lightning.png" width="20%" 
-       id="Fork Lightning" title="⚡ Deal 6 damage and stun to up to 6 visible characters.">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Elektra's%20Siphon.png" width="20%" 
-       id="Elektra's Siphon" title="⚡Cause a complete blackout in a 100 kilometre radius. Draw 3 copies of Fork Lightning.">
-</p>
-
-Certain cards like 
+  <i><a href="#Poltergeist" title="⚡ Possess a non-magic object within 5 tiles of your body until you lose concentration.">Poltergeist</a></i>, some alter the world. Like
  <i><a href="#Untimely Death" title="⚡ Name an NPC. They will be suddenly inspired to seek greatness. By next session they will be incredibly powerful.">Untimely Death</a></i>, and 
- <i><a href="#Heroic Inspiration" title="⚡ Name a character not on the current map. They die.">Heroic Inspiration</a></i>
-can even be used to influence the campaign at-large.
+ <i><a href="#Heroic Inspiration" title="⚡ Name a character not on the current map. They die.">Heroic Inspiration</a></i>, some can change the story.
+ 
+<br>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Barrier.png" width="19%" 
+       id="Barrier" title="⚡ Summon an impenetrable column of light in adjacent square metre for 5 minutes">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Soak.png" width="19%" 
+       id="Soak" title="⚡ Cause everything within 2 metres of a visible object to become saturated with water">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Poltergeist.png" width="19%" 
+       id="Poltergeist" title="⚡ Possess a non-magic object within 5 tiles of your body until you lose concentration.">
+    <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Untimely%20Death.png" width="19%" 
+       id="Untimely Death" title="⚡ Name a character not on the current map. They die.">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Heroic%20Inspiration.png" width="19%" 
+       id="Heroic Inspiration" title="⚡ Name an NPC. They will be suddenly inspired to seek greatness. By next session they will be incredibly powerful.">
+</p>
+
+While held, cards can have a **✋ Hand Effect**. As with
+  <i><a href="#Swarm" title="⚡ Pick a small animal or insect for your target to be swarmed by. &#013;✋ You are constantly covered in an insect of your choice">Swarm</a></i>, 
+  <i><a href="#Slingshot" title="⚡ Launch a baseball sized rock at a visible target. &#013;✋ Gain advantage when throwing objects.">Slingshot</a></i>, and
+  <i><a href="#Lover Fatale" title="⚡ A visible NPC develops feelings for you. &#013;✋ Attacks against characters who love you deal 25 bonus damage.">Lover Fatale</a></i>,
+these can help build a character's identity.
 
 <br>
 <p align="center">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Untimely%20Death.png" width="30%" 
-       id="Untimely Death" title="⚡ Name a character not on the current map. They die.">
-  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Heroic%20Inspiration.png" width="30%" 
-       id="Heroic Inspiration" title="⚡ Name an NPC. They will be suddenly inspired to seek greatness. By next session they will be incredibly powerful.">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Swarm.png" width="30%" 
+       id="Swarm" title="⚡ Pick a small animal or insect for your target to be swarmed by. &#013;✋ YYou are constantly covered in an insect of your choice">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Slingshot.png" width="30%" 
+       id="Slingshot" title="⚡ Launch a baseball sized rock at a visible target. &#013;✋ Gain advantage when throwing objects.">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lover%20Fatale.png" width="30%" 
+       id="Lover Fatale" title="⚡ A visible NPC develops feelings for you. &#013;✋ Attacks against characters who love you deal 25 bonus damage.">
+</p>
+
+The tiers are ⚫Grey, 🔵Blue, 🟢Green, 🔴Red, and 🟡Gold. The player can upgrade a card in exchange for three of the same tier.
+
+<br>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Spark.png" width="24%" 
+       id="Spark" title="⚡ Deal 3 damage to a visible character with a painful bolt of electricity">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Lightning%20Bolt.png" width="24%" 
+       id="Lightning Bolt" title="⚡ Deal 4 damage and stun up to 2 visible characters.">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Fork%20Lightning.png" width="24%" 
+       id="Fork Lightning" title="⚡ Deal 6 damage and stun to up to 6 visible characters.">
+  <img src="https://raw.githubusercontent.com/elliottomlinson/cardmaster/master/res/card/generated/Elektra's%20Siphon.png" width="24%" 
+       id="Elektra's Siphon" title="⚡Cause a complete blackout in a 100 kilometre radius. Draw 3 copies of Fork Lightning.">
 </p>
 
 ## In This Repository
@@ -121,8 +107,8 @@ can even be used to influence the campaign at-large.
 - *Cardmaster*'s website, located at https://cardmaster.io/
 
 
-## Authors
+## Credits
 
-[Duncan Uszkay](https://github.com/DuncanUszkay1) and [Elliot Tomlinson](https://github.com/elliottomlinson)
+Created by [Duncan Uszkay](https://github.com/DuncanUszkay1) and [Elliot Tomlinson](https://github.com/elliottomlinson)
 
 © 2021 Cardmaster


### PR DESCRIPTION
Added links for the purpose of legibility, now you can read the effect in the hover text without navigating away from the page. The links themselves are local and will just scroll you to the card image. Hovering the card shows the effect tooltip as well.

![image](https://user-images.githubusercontent.com/8680290/131724382-32f8b700-0336-49b2-925e-5640e2973340.png)
