### PR TITLE
Remove word warp

### DIFF
--- a/data/card_catalogue/social.json
+++ b/data/card_catalogue/social.json
@@ -143,19 +143,6 @@
     }
   },
   {
-    "title": "Word Warp",
-    "upgrade": null,
-    "tier": "blue",
-    "details": {
-      "rules": {
-        "active": "Swap two words in an NPC's vocabulary. They will not be aware of the effect, which lasts for a day.",
-        "passive": null
-      },
-      "flavour": "",
-      "image": "res/art/illustration/Word Warp.png"
-    }
-  },
-  {
     "title": "Magic Trick",
     "upgrade": null,
     "tier": "red",

--- a/data/card_catalogue/upgradeable-1.json
+++ b/data/card_catalogue/upgradeable-1.json
@@ -175,7 +175,7 @@
     "details": {
       "rules": {
         "active": "Jump 25 metres into the air.",
-        "passive": null
+        "passive": "Take no damage from falling."
       },
       "flavour": "Sometimes all you need is a big leap of faith.",
       "image": "res/art/illustration/Leap.png"


### PR DESCRIPTION
This card doesn't meet the [card heuristic](https://github.com/elliottomlinson/cardmaster/wiki/Card-Design-Heuristics) for blues, since it's not a reliable distraction.

I think there's a design space for having opponents say something they don't want to say, I think this is a little limited and challenging to use.

Some proposed alternatives that occupy a similar space:
```
Impersonate: Your next sentence will be spoken in the voice of a character of your choosing

Voice Slip: A character is forced to vocalize their thoughts

Puppeteer: A character you are touching goes into trance. For as long as you continue touching them, you can command them to say anything you'd like.
```

