### PR TITLE
Rework strike cards

### DIFF
--- a/data/card_catalogue/upgradeable-1.json
+++ b/data/card_catalogue/upgradeable-1.json
@@ -408,7 +408,7 @@
     "tier": "blue",
     "details": {
       "rules": {
-        "active": "Make up to two instant attacks.",
+        "active": "Make two instant attacks.",
         "passive": null
       },
       "flavour": "The first blow shatters their defenses, the next their spirit.",
@@ -421,7 +421,7 @@
     "tier": "green",
     "details": {
       "rules": {
-        "active": "Make up to four instant attacks",
+        "active": "Make four instant attacks",
         "passive": null
       },
       "flavour": "Their defense won't last forever. Strike, and strike again.",

--- a/data/card_catalogue/upgradeable-1.json
+++ b/data/card_catalogue/upgradeable-1.json
@@ -60,7 +60,7 @@
         "active": "Deal 3 damage to a visible character with a painful bolt of electricity",
         "passive": null
       },
-      "flavour": "A smile costs less than electricity, but gives much light",
+      "flavour": "A spark is a little thing, yet it may kindle the world.",
       "image": "res/art/illustration/Spark.png"
     }
   },
@@ -408,20 +408,20 @@
     "tier": "blue",
     "details": {
       "rules": {
-        "active": "You can attack two additional times on your turn.",
+        "active": "Make up to two instant attacks.",
         "passive": null
       },
-      "flavour": "Before they even realized what happened, another punch sent them flying.",
+      "flavour": "The first blow shatters their defenses, the next their spirit.",
       "image": "res/art/illustration/Double Strike.png"
     }
   },
   {
     "title": "Quad Strike",
-    "upgrade": "Strike Storm",
+    "upgrade": "Endless Blows",
     "tier": "green",
     "details": {
       "rules": {
-        "active": "You can attack four additional times on your turn.",
+        "active": "Make up to four instant attacks",
         "passive": null
       },
       "flavour": "Their defense won't last forever. Strike, and strike again.",
@@ -429,28 +429,15 @@
     }
   },
   {
-    "title": "Strike Storm",
-    "upgrade": "Endless blows",
+    "title": "Endless Blows",
+    "upgrade": "",
     "tier": "red",
     "details": {
       "rules": {
-        "active": "You can make twice times as many attacks as you otherwise would on your turn.",
+        "active": "Take X damage. Make X instant attacks",
         "passive": null
       },
-      "flavour": "Every fighter has gaps between attacks which can be exploited. Just make sure to take them after your opponent is dead.",
-      "image": "res/art/illustration/Strike Storm.png"
-    }
-  },
-  {
-    "title": "Endless Blows",
-    "upgrade": null,
-    "tier": "gold",
-    "details": {
-      "rules": {
-        "active": "Take X damage. You can attack X times on your turn.",
-        "passive": null
-      },
-      "flavour": "Punches, kicks, and jabs stretch out before me into endless infinity, a fractal of iron striking limbs.",
+      "flavour": "An endless fractal of striking limbs",
       "image": "res/art/illustration/Endless Blows.png"
     }
   },


### PR DESCRIPTION
A couple issues with the strike series:

- It has a gold card that does not change the plot. I've moved the gold effect down to red
- The red version of this effect only makes sense in combat, and is a little tricky to keep track of. I opted for the old gold version instead
- The wording references your turn, which isn't ideal when drawn randomly. Instead, I'd like the card to just let you make instant attacks regardless of combat status