### PR TITLE
Add ability to query drafts

### DIFF
--- a/lib/card/catalogue_adapters/json_catalogue_adapter.rb
+++ b/lib/card/catalogue_adapters/json_catalogue_adapter.rb
@@ -83,10 +83,9 @@ module Card
       end
 
       def build_card(card, parent_names)
-        return if card["draft"]
-
         name_hierarchy = parent_names + [card["title"]]
 
+        draft = card["draft"] || false
         title = validate_field!(card, "title", name_hierarchy, "Card")
         details = validate_field!(card, "details", name_hierarchy, "Card")
         flavour = validate_field!(details, "flavour", name_hierarchy, "Card")
@@ -97,7 +96,7 @@ module Card
 
         upgrade = card["upgrade"]
 
-        Card::Models::CardSpecification.new(title, rules, upgrade, tier, flavour, image_path, parent_names)
+        Card::Models::CardSpecification.new(title, rules, upgrade, tier, flavour, image_path, draft, parent_names)
       end
 
       def validate_tier!(card, name_hierarchy)

--- a/lib/card/models/card_specification.rb
+++ b/lib/card/models/card_specification.rb
@@ -5,15 +5,16 @@ module Card
     class CardSpecification
       TIER_HIERARCHY = [:grey, :blue, :green, :red, :gold].freeze
 
-      attr_accessor :title, :rules, :upgrade, :tier, :flavour, :art_path, :tags
+      attr_accessor :title, :rules, :upgrade, :tier, :flavour, :art_path, :tags, :draft
 
-      def initialize(title, rules, upgrade, tier, flavour, art_path, tags=[])
+      def initialize(title, rules, upgrade, tier, flavour, art_path, draft, tags=[])
         @title = title
         @rules = rules
         @upgrade = upgrade
         @tier = validate_tier!(tier)
         @flavour = flavour
         @art_path = art_path
+        @draft = draft
         @tags = tags
       end
 

--- a/lib/cardmaster/commands/generate.rb
+++ b/lib/cardmaster/commands/generate.rb
@@ -71,7 +71,7 @@ module Cardmaster
       def catalogue_info
         CLI::UI::Frame.open("Retrieving Catalogue Info", color: :blue) do
           stored_card_specs = storage_adapter.stored_cards.map(&:spec)
-          card_specs = catalogue_adapter.card_specifications
+          card_specs = catalogue_adapter.card_specifications.select { |card| !card.draft }
 
           puts CLI::UI.fmt "{{*}} Cards recorded in storage manifest: #{stored_card_specs.length}"
           puts CLI::UI.fmt "{{*}} Cards specified in catalogue: #{card_specs.length}"

--- a/lib/cardmaster/commands/query.rb
+++ b/lib/cardmaster/commands/query.rb
@@ -5,7 +5,7 @@ module Cardmaster
     class Query < Cardmaster::Command
       include Arguments
 
-      SUPPORTED_PARAMETERS = ["title"].freeze
+      SUPPORTED_PARAMETERS = ["title", "draft"].freeze
 
       def call(args, _name)
         query_parameters = validate_parameters(named_arguments(args))
@@ -16,7 +16,7 @@ module Cardmaster
         end
 
         results = Card::CatalogueAdapters::JsonCatalogueAdapter.new("data/card_catalogue")
-          .printable_cards
+          .card_specifications
           .select { |card_spec| matches_query(card_spec, query_parameters) }
 
         CLI::UI::Frame.open('Search Results') do
@@ -48,6 +48,7 @@ module Cardmaster
 
       def matches_query(card_spec, query_parameters)
         match_if_present(query_parameters, "name", card_spec.title)
+        match_if_present(query_parameters, "draft", card_spec.draft.to_s)
       end
 
       def match_if_present(parameters, parameter_name, value)


### PR DESCRIPTION
I wanted to be able to run a command to get all card drafts.

1. Added draft as a property of the card specification
2. Stopped skipping cards with the draft field in the json catalogue adaptor
3. changed query command to look for that field